### PR TITLE
Change font-awesome class prefix to prevent some fonts from not working

### DIFF
--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -2,6 +2,16 @@
 @import 'libs/functions';
 @import 'libs/mixins';
 @import 'libs/skel';
+
+//Override font-awesome variables
+$fa-css-prefix: 'fas';
+
+@import '../../node_modules/font-awesome/scss/variables';
+@import '../../node_modules/font-awesome/scss/mixins';
+@import '../../node_modules/font-awesome/scss/path';
+@import '../../node_modules/font-awesome/scss/core';
+@import '../../node_modules/font-awesome/scss/icons';
+
 @import url('http://fonts.googleapis.com/css?family=Source+Sans+Pro:300');
 
 /*

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,9 +6,8 @@ var gulp = require('gulp'),
     minifyCss = require('gulp-minify-css');
 
 gulp.task('css', function () {
-  gulp.src(['node_modules/font-awesome/scss/**/*scss', 'assets/sass/**/*scss'])
+  gulp.src(['assets/sass/**/*scss'])
       .pipe(sass())
-      .pipe(concatCss('bundle.css'))
       .pipe(minifyCss())
       .pipe(gulp.dest('dist/css'))
       .pipe(browserSync.stream());

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<!--[if lte IE 8]><script src="js/html5shiv.js"></script><![endif]-->
-		<link rel="stylesheet" href="css/bundle.css" />
+		<link rel="stylesheet" href="css/main.css" />
 		<!--[if lte IE 9]><link rel="stylesheet" href="css/ie9.css" /><![endif]-->
 		<!--[if lte IE 8]><link rel="stylesheet" href="css/ie8.css" /><![endif]-->
 		<noscript><link rel="stylesheet" href="css/noscript.css" /></noscript>
@@ -66,10 +66,10 @@
 						-->
 						<footer>
 							<ul class="icons">
-                <li><a href="http://sankakuvalidator.hatenablog.com" class="fa-rss">Blog</a></li>
-                <li><a href="https://github.com/distkloc" class="fa-github">GitHub</a></li>
-								<li><a href="https://twitter.com/distkloc" class="fa-twitter">Twitter</a></li>
-								<li><a href="https://instagram.com/distkloc/" class="fa-instagram">Instagram</a></li>
+                <li><a href="http://sankakuvalidator.hatenablog.com" class="fas fas-rss">Blog</a></li>
+                <li><a href="https://github.com/distkloc" class="fas fas-github">GitHub</a></li>
+								<li><a href="https://twitter.com/distkloc" class="fas fas-twitter">Twitter</a></li>
+								<li><a href="https://instagram.com/distkloc/" class="fas fas-instagram">Instagram</a></li>
 							</ul>
 						</footer>
 					</section>


### PR DESCRIPTION
Some fonts doens't work because a contents blocker extension for browser blocks several social icon fonts.
This patch loads basic font-awesome css and changes the class name prefix that is used as blocked trigger.
